### PR TITLE
fix weird space at header

### DIFF
--- a/resources/views/widgets/components/header.blade.php
+++ b/resources/views/widgets/components/header.blade.php
@@ -5,7 +5,7 @@
             {!! $heading !!}
         </x-filament::card.heading>
 
-        <div class="relative my-32 h-10">
+        <div class="relative h-10">
 
             <div class="flex items-center justify-between gap-4">
                 @if ($filters)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52034225/223335971-7a6245a9-1065-4163-9186-b08328fd22b7.png)
that class make space at my chart looks weird