### PR TITLE
Fix dark mode if theme is not set

### DIFF
--- a/resources/views/widgets/components/chart.blade.php
+++ b/resources/views/widgets/components/chart.blade.php
@@ -3,7 +3,7 @@
         <div {!! $pollingInterval ? 'wire:poll.' . $pollingInterval . '="updateChartOptions"' : '' !!} class="w-full" id="{{ $chartId }}" x-data="{
             chart: null,
             darkModeEnabled: {{ $darkModeEnabled ? 'true' : 'false' }},
-            mode: localStorage.getItem('theme'),
+            mode: localStorage.getItem('theme') || document.documentElement.classList.contains('dark') ? 'dark' : 'light',
             init: function() {
                 let chart = this.initChart()
         


### PR DESCRIPTION
If `theme` is not set in localStorage (e.g. a user did not choose the theme to use), fallback to the theme used by filament (if OS uses dark mode, there is a `dark` class in the body)