### PR TITLE
No longer need to wrap FilamentAsset::register() in resolving()

### DIFF
--- a/src/FilamentApexChartsServiceProvider.php
+++ b/src/FilamentApexChartsServiceProvider.php
@@ -39,10 +39,8 @@ class FilamentApexChartsServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->resolving(AssetManager::class, function () {
-            FilamentAsset::register([
-                Js::make('apexcharts', __DIR__.'/../dist/apexcharts.js'),
-            ], package: 'leandrocfe/filament-apex-charts');
-        });
+        FilamentAsset::register([
+            Js::make('apexcharts', __DIR__ . '/../dist/apexcharts.js'),
+        ], package: 'leandrocfe/filament-apex-charts');
     }
 }


### PR DESCRIPTION
As of (I think) alpha-99, you should no longer wrap FilamentAsset::register() calls inside an app()->resolving(), as Filament now handles that internally.  Asset manager calls still wrapped in a resolving will not work.