### PR TITLE
fixed CanValidateInput not found trait

### DIFF
--- a/src/Commands/FilamentApexChartsCommand.php
+++ b/src/Commands/FilamentApexChartsCommand.php
@@ -3,7 +3,7 @@
 namespace Leandrocfe\FilamentApexCharts\Commands;
 
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+use Leandrocfe\FilamentApexCharts\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;

--- a/src/Concerns/CanValidateInput.php
+++ b/src/Concerns/CanValidateInput.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leandrocfe\FilamentApexCharts\Concerns;
+
+use Closure;
+use Illuminate\Support\Facades\Validator;
+
+trait CanValidateInput
+{
+    protected function askRequired(string $question, string $field, ?string $default = null): string
+    {
+        return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
+    }
+
+    /**
+     * @param  array<array-key>  $rules
+     */
+    protected function validateInput(Closure $askUsing, string $field, array $rules, ?Closure $onError = null): string
+    {
+        $input = $askUsing();
+
+        $validator = Validator::make(
+            [$field => $input],
+            [$field => $rules],
+        );
+
+        if ($validator->fails()) {
+            $this->components->error($validator->errors()->first());
+
+            if ($onError) {
+                $onError($validator);
+            }
+
+            $input = $this->validateInput($askUsing, $field, $rules);
+        }
+
+        return $input;
+    }
+}


### PR DESCRIPTION
In the Filament v3.0.9 release, the maintainer removed the `CanValidateInput` trait. I have taken the initiative to reintroduce it. It's a quick fixed. Please feel free to close this pull request if there's anything I've overlooked. 