### PR TITLE
Make simple filter select reactive by default

### DIFF
--- a/resources/views/widgets/components/header.blade.php
+++ b/resources/views/widgets/components/header.blade.php
@@ -19,7 +19,7 @@
 
             <div>
                 @if ($filters)
-                    <select wire:model="filter" @class([
+                    <select wire:model.live="filter" @class([
                         'apex-charts-single-filter w-full text-gray-900 border-gray-300 block h-10 transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:focus:border-primary-500',
                     ]) wire:loading.class="animate-pulse">
                         @foreach ($filters as $value => $label)


### PR DESCRIPTION
Fixes a bug where the simple filter won't re-render the chart, as it's not reactive by default.