### PR TITLE
Updated async script loading to AsyncAlpine v2 syntax

### DIFF
--- a/resources/views/widgets/components/chart.blade.php
+++ b/resources/views/widgets/components/chart.blade.php
@@ -14,8 +14,8 @@
     style="{{ $contentHeight ? 'height: ' . $contentHeight . 'px;' : '' }}">
     @if ($readyToLoad)
         <div id="chart"></div>
-        <div x-ignore ax-load
-            ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('apexcharts') }}"
+        <div x-ignore x-load
+            x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('apexcharts') }}"
             x-data="apexcharts({
                 options: @js($chartOptions),
                 chartId: '#{{ $chartId }}',


### PR DESCRIPTION
This commit on Filament https://github.com/filamentphp/filament/commit/af36dec35113be5747e12f013dd288d7287ce533 upgraded AsyncAlpine from v1 to v2, which has a major breaking change (https://async-alpine.dev/docs/upgrade). The attributes `ax-load` and `ax-load-src` dropped the "a" and now are called `x-load` and `x-load-src`.

Fixes https://github.com/leandrocfe/filament-apex-charts/issues/110