### PR TITLE
Small fix on z-index for filter dropdown options

### DIFF
--- a/resources/views/widgets/components/filter-form.blade.php
+++ b/resources/views/widgets/components/filter-form.blade.php
@@ -35,7 +35,7 @@
     <div x-show="dropdownOpen" x-cloak @click="dropdownOpen = false" class="fixed inset-0 h-full w-full z-10"></div>
 
     <div x-show="dropdownOpen" x-cloak @class([
-        'absolute mt-2 z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-gray-700 dark:bg-gray-800 dark:ring-white/20',
+        'absolute mt-2 z-20 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-gray-700 dark:bg-gray-800 dark:ring-white/20',
     ])
         style="{{ match ($width) {
             MaxWidth::ExtraSmall, 'xs' => 'width: 20rem;',


### PR DESCRIPTION
### Fix z-index overlap between filter dropdown and ApexCharts download menu

When filter options are triggered, the ApexCharts built-in Download menu appears above the filter dropdown:

![image](https://github.com/user-attachments/assets/270a6521-3e3a-4230-84b3-ee7769de8b17)

One quick fix is to simply publish the plugin views:

`php artisan vendor:publish --tag="filament-apex-charts-views"`

And finally 'fix' the z-index in the _resources/views/vendor/filament-apex-charts/widgets/components/filter-form.blade.php_ from:

![image](https://github.com/user-attachments/assets/fe6e344c-ef97-40ff-87f6-94b813081fc4)

to: 

![image](https://github.com/user-attachments/assets/dbdfb4f2-b211-470f-a42b-fa6c088b44de)

In which the desired behavior is then achieved:

![image](https://github.com/user-attachments/assets/ec463835-db10-42bf-88f8-9d0a4872196e)


This PR adjusts the z-index of the filter form dropdown in _filter-form.blade.php_ to ensure it appears above the chart's menu without the need to publish the plugin views.

This resolves the UI conflict and improves usability when interacting with filter options.