### PR TITLE
feat: Filament V4 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ protected function getFormSchema(): array
 You can change the filter form width by setting the `$filterFormWidth` property:
 
 ```php
-use Filament\Support\Enums\MaxWidth;
-protected static MaxWidth|string $filterFormWidth = MaxWidth::Medium;
+use Filament\Support\Enums\Width;
+protected static Width|string $filterFormWidth = Width::Medium;
 ```
 
 ### Single select

--- a/composer.json
+++ b/composer.json
@@ -17,24 +17,24 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
-        "filament/widgets": "^3.0",
-        "filament/forms": "^3.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "php": "^8.2",
+        "filament/widgets": "^v4.0.0-beta10",
+        "filament/forms": "^v4.0.0-beta10",
+        "illuminate/contracts": "^11.0|^12.0",
         "livewire/livewire": "^3.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.0.1",
+        "larastan/larastan": "^3.0.1",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0|^8.0",
-        "orchestra/testbench": "8.14|^9.0",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/widgets/components/filter-form.blade.php
+++ b/resources/views/widgets/components/filter-form.blade.php
@@ -1,7 +1,7 @@
 @props(['indicatorsCount', 'width'])
 
 @php
-    use Filament\Support\Enums\MaxWidth;
+    use Filament\Support\Enums\Width;
 @endphp
 
 <div class="filament-apex-charts-filter-form relative">
@@ -38,17 +38,17 @@
         'absolute mt-2 z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-gray-700 dark:bg-gray-800 dark:ring-white/20',
     ])
         style="{{ match ($width) {
-            MaxWidth::ExtraSmall, 'xs' => 'width: 20rem;',
-            MaxWidth::Small, 'sm' => 'width: 24rem;',
-            MaxWidth::Medium, 'md' => 'width: 28rem;',
-            MaxWidth::Large, 'lg' => 'width: 32rem;',
-            MaxWidth::ExtraLarge, 'xl' => 'width: 36rem;',
-            MaxWidth::TwoExtraLarge, '2xl' => 'width: 42rem;',
-            MaxWidth::ThreeExtraLarge, '3xl' => 'width: 48rem;',
-            MaxWidth::FourExtraLarge, '4xl' => 'width: 56rem;',
-            MaxWidth::FiveExtraLarge, '5xl' => 'width: 64rem;',
-            MaxWidth::SixExtraLarge, '6xl' => 'width: 72rem;',
-            MaxWidth::SevenExtraLarge, '7xl' => 'width: 80rem;',
+            Width::ExtraSmall, 'xs' => 'width: 20rem;',
+            Width::Small, 'sm' => 'width: 24rem;',
+            Width::Medium, 'md' => 'width: 28rem;',
+            Width::Large, 'lg' => 'width: 32rem;',
+            Width::ExtraLarge, 'xl' => 'width: 36rem;',
+            Width::TwoExtraLarge, '2xl' => 'width: 42rem;',
+            Width::ThreeExtraLarge, '3xl' => 'width: 48rem;',
+            Width::FourExtraLarge, '4xl' => 'width: 56rem;',
+            Width::FiveExtraLarge, '5xl' => 'width: 64rem;',
+            Width::SixExtraLarge, '6xl' => 'width: 72rem;',
+            Width::SevenExtraLarge, '7xl' => 'width: 80rem;',
             default => $width,
         } }}; right:0">
         <div class="py-4 px-6">

--- a/src/Concerns/CanFilter.php
+++ b/src/Concerns/CanFilter.php
@@ -3,14 +3,14 @@
 namespace Leandrocfe\FilamentApexCharts\Concerns;
 
 use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Support\Enums\MaxWidth;
+use Filament\Support\Enums\Width;
 use Illuminate\Support\Arr;
 
 trait CanFilter
 {
     use InteractsWithForms;
 
-    protected static MaxWidth|string $filterFormWidth = MaxWidth::ExtraSmall;
+    protected static Width|string $filterFormWidth = Width::ExtraSmall;
 
     public ?string $filter = null;
 
@@ -115,9 +115,9 @@ trait CanFilter
     /**
      * Retrieves the value of the static property $filterFormWidth.
      *
-     * @return MaxWidth | string The value of the $filterFormWidth property, which is either a MaxWidth instance or a string.
+     * @return Width | string The value of the $filterFormWidth property, which is either a MaxWidth instance or a string.
      */
-    protected function getFilterFormWidth(): MaxWidth|string
+    protected function getFilterFormWidth(): Width|string
     {
         return static::$filterFormWidth;
     }

--- a/src/Widgets/ApexChartWidget.php
+++ b/src/Widgets/ApexChartWidget.php
@@ -29,7 +29,7 @@ class ApexChartWidget extends Widget implements HasForms
 
     protected static ?string $chartId = null;
 
-    protected static string $view = 'filament-apex-charts::widgets.apex-chart-widget';
+    protected string $view = 'filament-apex-charts::widgets.apex-chart-widget';
 
     public ?array $options = null;
 
@@ -51,7 +51,7 @@ class ApexChartWidget extends Widget implements HasForms
 
     public function render(): View
     {
-        return view(static::$view, []);
+        return view($this->view, []);
     }
 
     /**


### PR DESCRIPTION
Hello Leandro! This PR provides the V4 upgrade for the Apex Charts plugin. Some points:

- I have upgraded all dependencies to work with Filament V4 and removed those that are impossible to combine with Filament V4. Filament V4 requires Laravel 11, which in turn requires a minimum PHP 8.2. Pest and Larastan etc are also upgraded.
- `MaxWidth` enum renamed.
- Apart from that it appeared to work well, but perhaps you can do one short sanity check on a demo-project or a project by yourself.

Thanks!