### PR TITLE
Fix occassional Cannot assign null to property Leandrocfe\FilamentApe…xCharts\Commands\FilamentApexChartsCommand::$chartOptions of type array error during deployments

### DIFF
--- a/src/Commands/FilamentApexChartsCommand.php
+++ b/src/Commands/FilamentApexChartsCommand.php
@@ -50,7 +50,7 @@ class FilamentApexChartsCommand extends Command
         parent::__construct();
 
         $this->files = $files;
-        $this->chartOptions = config('filament-apex-charts.chart_options');
+        $this->chartOptions = config('filament-apex-charts.chart_options') ?? [];
     }
 
     public function handle(): int


### PR DESCRIPTION
It happen a couple of times every month

During deployment Sentry will give me this error (The deployment with Envoyer still succeeds)

<img width="2886" height="178" alt="CleanShot 2025-07-20 at 23 45 02@2x" src="https://github.com/user-attachments/assets/a7cc9f05-69ee-46b6-8d69-1fbfabf88430" />

So it is getting quite annoying. Hence this PR.

It is really strange to me though since `config('filament-apex-charts.chart_options')` is indeed an array