### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.1|^8.2",
         "filament/widgets": "^3.0",
         "filament/forms": "^3.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "livewire/livewire": "^3.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },


### PR DESCRIPTION
Adds Laravel 13 support to the `3.x` (Filament v3) line by widening the `illuminate/contracts` constraint.

## Summary
- `illuminate/contracts`: `^9.0|^10.0|^11.0|^12.0` → `^9.0|^10.0|^11.0|^12.0|^13.0`

No code changes are required — the package uses only stable APIs (`Illuminate\Console\Command`, `Support\Arr`/`Str`, Blade `View\Component`, `Filesystem`) and Filament v3 / Livewire v3 components, none of which changed in Laravel 13.