### PR TITLE
Refresh chart options before each render

### DIFF
--- a/resources/views/widgets/apex-chart-widget.blade.php
+++ b/resources/views/widgets/apex-chart-widget.blade.php
@@ -8,7 +8,7 @@
     $width = $this->getFilterFormWidth();
     $pollingInterval = $this->getPollingInterval();
     $chartId = $this->getChartId();
-    $chartOptions = $this->getOptions();
+    $chartOptions = $this->options;
     $loadingIndicator = $this->getLoadingIndicator();
     $contentHeight = $this->getContentHeight();
     $deferLoading = $this->getDeferLoading();

--- a/src/Widgets/ApexChartWidget.php
+++ b/src/Widgets/ApexChartWidget.php
@@ -49,6 +49,24 @@ class ApexChartWidget extends Widget implements HasSchemas
 
     public function on(): void {}
 
+    /**
+     * Refresh the options before every render.
+     *
+     * `mount()` only runs once, so without this the chart keeps drawing the data
+     * it was mounted with: a widget whose options depend on component state that
+     * changes later — a `#[Reactive]` property fed by a Filament page filter, a
+     * Livewire property, the clock — updates its heading and leaves the chart
+     * behind, with nothing to signal it. Filament's own `ChartWidget` refreshes
+     * the same way, in the same hook.
+     *
+     * `updateOptions()` compares before dispatching, so a render that changes
+     * nothing still emits no browser event.
+     */
+    public function rendering(): void
+    {
+        $this->updateOptions();
+    }
+
     public function render(): View
     {
         return view('filament-apex-charts::widgets.apex-chart-widget', []);

--- a/tests/Fixtures/ReadingChartWidget.php
+++ b/tests/Fixtures/ReadingChartWidget.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Leandrocfe\FilamentApexCharts\Tests\Fixtures;
+
+use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
+
+class ReadingChartWidget extends ApexChartWidget
+{
+    protected static ?string $chartId = 'reading';
+
+    public int $reading = 1;
+
+    protected function getOptions(): array
+    {
+        return ['series' => [['name' => 'reading', 'data' => [$this->reading]]]];
+    }
+}

--- a/tests/StaleOptionsTest.php
+++ b/tests/StaleOptionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Leandrocfe\FilamentApexCharts\Tests\Fixtures\ReadingChartWidget;
+
+it('refreshes its options before each render, not only on mount', function () {
+    $widget = new ReadingChartWidget;
+    $widget->mount();
+
+    expect($widget->options['series'][0]['data'])->toBe([1]);
+
+    // Whatever the options are derived from has changed since mount — a reactive
+    // property fed by a page filter, a Livewire property, the clock.
+    $widget->reading = 2;
+    $widget->rendering();
+
+    expect($widget->options['series'][0]['data'])->toBe([2]);
+});


### PR DESCRIPTION
Fixes #171.

## The problem

`mount()` runs once, so `$this->options` keeps whatever the widget was mounted with. On a full page load that stays invisible — the view calls `getOptions()` again and Alpine initialises from it. On a **Livewire round-trip** it does not: the chart container is `wire:ignore` and the `x-data` element is `x-ignore`, so nothing re-initialises the chart, and the only thing that can update it in the browser is the `updateOptions` event — dispatched from `updatedFilter()`, `submitFiltersForm()`, `resetFiltersForm()` and `wire:poll`, and nowhere else.

So any *other* state the options are derived from never reaches the chart. What surfaced it for me: a widget using Filament's `InteractsWithPageFilters`, whose `$pageFilters` arrive as a `#[Reactive]` property. Changing the dashboard period moved the heading and subheading — they are recomputed every render — and left the chart drawing the period it was mounted with. Nothing errored, nothing logged; the header just stopped matching the picture under it.

## The change

Two lines, plus a test.

- `ApexChartWidget::rendering()` → `updateOptions()`. This is the hook Filament's own `ChartWidget` uses for exactly this job (`ChartWidget::rendering()` → `updateChartData()`), so the behaviour now matches what people expect from a Filament chart widget.
- the view reads `$this->options` instead of calling `$this->getOptions()` a second time.

## It does not cost an extra `getOptions()` call

The obvious objection, so: today the first request calls `getOptions()` **twice** (`mount()` and the view) and every later render **once** (the view). After this change it is twice on the first request (`mount()` and `rendering()`) and once on every later render — `rendering()`, with the view reusing its result. Identical either way.

`updateOptions()` already compares the new options against the old before dispatching, so a render that changes nothing still emits no browser event.

A side effect worth mentioning: reading `$this->options` in the view hands Alpine the array **after** `processOptions()`, so backed enums are converted on the initial render too. Today the first render passes the raw array and only later updates get them converted.

## Test

`tests/StaleOptionsTest.php` drives the hook directly on an instance, so it needs no Livewire container or Filament panel and stays in line with the suite's existing weight. It fails on `5.x` (no `rendering()` method) and passes with the change.

Verified on `1353ad7`: `vendor/bin/pest` (8 passed), `vendor/bin/pint --test` and `vendor/bin/phpstan analyse` all clean.
